### PR TITLE
Update DAC links and allow sidebar links to scroll w/ page

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -775,6 +775,7 @@ footer path {
 
 nav.nav-list {
   top: 215px;
+  position: unset;
 }
 
 .sidebar .nav > li > a {

--- a/views/header.html
+++ b/views/header.html
@@ -65,13 +65,13 @@
             <a id="drop3" href="#" class="dropdown-toggle" data-toggle="dropdown" role="button"  aria-haspopup="true" aria-expanded="false">DACs <span class="caret"></span></a>
             <ul class="dropdown-menu" aria-labelledby="drop3">
               <li>
-                <a href="//gliders.ioos.us/data/">Glider DAC</a>
+                <a href="//gliders.ioos.us">Glider DAC</a>
               </li>
               <li>
                 <a href="//hfradar.ioos.us/">HF Radar DAC</a>
               </li>
               <li>
-                <a href="http://oceanview.pfeg.noaa.gov/ATN/" target="_blank">ATN DAC</a>
+                <a href="https://atn.ioos.us" target="_blank">ATN DAC</a>
               </li>
             </ul>
           </li>


### PR DESCRIPTION
@torieketcham This should fix the CSS issue with scrolling on the projects page on small screens. I'm overriding the css that Bootstrap uses to the affix class by setting position to unset in the main css file.

**If you want to test this you can:**
You can find the pull request by looking at the url, it will look like this:
```
https://github.com/ioos/comt-landing/pull/21
```
Then replace EnterMyPullNumberHere with actual pull number such as 21
In this example replace with 21, since that is my pr number.
```
git fetch upstream pull/EnterMyPullNumberHere/head:WhatEverYouWantForBranchNameHere
git checkout WhateverYouCalledYourBranchNameHere
grunt
DEBUG=comt-landing:* npm start
then test in browser
```

https://github.com/ioos/ioos-us/issues/195

