### PR TITLE
Fix Docker build and bump version to 1.0.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN useradd -m node
 
 COPY contrib/scripts/ $SCRIPTS_DIR/
 
+RUN sed -i '/jessie-updates/d' /etc/apt/sources.list  # Now archived
 RUN $SCRIPTS_DIR/install-deps.sh
 RUN $SCRIPTS_DIR/install-node.sh
 COPY bin /opt/ioos-us/bin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comt-landing",
-  "version": "1.0.9",
+  "version": "1.0.11",
   "private": true,
   "scripts": {
     "start": "node ./bin/www"


### PR DESCRIPTION
Docker build failing due to update to Ubuntu. Fixed w/ this:
https://github.com/debuerreotype/docker-debian-artifacts/issues/66#issuecomment-476616579

